### PR TITLE
Use quantity in price calculation in the home screen and show total price for the current filter in the home screen

### DIFF
--- a/lib/pages/edit_item.dart
+++ b/lib/pages/edit_item.dart
@@ -223,8 +223,13 @@ class _EditItemWidgetState extends State<EditItemWidget> {
                             }
                           },
                           validator: (value) {
-                            if (value != null && value != "" && (value.length >= 15 || double.parse(value) >= 1000000000000)) { // 1 trillion +
-                              return "Price cannot be this high";
+                            if (value != null && value != "") {
+                              if (value.split(".")[0].length >= 13) { // 1 trillion +
+                                return "Price cannot be this high";
+                              }
+                              if (value.length >= 15) {
+                                return "Price cannot be this long";
+                              }
                             }
                             return null;
                           },

--- a/lib/pages/edit_item.dart
+++ b/lib/pages/edit_item.dart
@@ -192,7 +192,7 @@ class _EditItemWidgetState extends State<EditItemWidget> {
                 ),
                 const Padding(
                   padding: EdgeInsets.fromLTRB(16, 8, 0, 0),
-                  child: Text("Price:"),
+                  child: Text("Price (for one):"),
                 ),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -290,9 +290,12 @@ class _EditItemWidgetState extends State<EditItemWidget> {
                         item.quantity = int.parse(value);
                       }
                     },
-                    validator: (value) { // Currently allows 0. Only because why not?
+                    validator: (value) {
                       if (value == null) {
                         return "Invalid value";
+                      }
+                      if (int.parse(value) == 0) {
+                        return "Quantity cannot be 0";
                       }
                       if (value != "" && int.parse(value) >= 1000000000) { // 1 billion +
                         return "Quantity can't be so high";

--- a/lib/pages/edit_item.dart
+++ b/lib/pages/edit_item.dart
@@ -192,7 +192,7 @@ class _EditItemWidgetState extends State<EditItemWidget> {
                 ),
                 const Padding(
                   padding: EdgeInsets.fromLTRB(16, 8, 0, 0),
-                  child: Text("Price (for one):"), // TODO: Is this the best label I have?
+                  child: Text("Price (per unit):"),
                 ),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/lib/pages/edit_item.dart
+++ b/lib/pages/edit_item.dart
@@ -223,7 +223,7 @@ class _EditItemWidgetState extends State<EditItemWidget> {
                             }
                           },
                           validator: (value) {
-                            if (value != null && value != "" && double.parse(value) >= 1000000000000) { // 1 trillion +
+                            if (value != null && value != "" && (value.length >= 15 || double.parse(value) >= 1000000000000)) { // 1 trillion +
                               return "Price cannot be this high";
                             }
                             return null;
@@ -294,11 +294,11 @@ class _EditItemWidgetState extends State<EditItemWidget> {
                       if (value == null) {
                         return "Invalid value";
                       }
-                      if (int.parse(value) == 0) {
-                        return "Quantity cannot be 0";
-                      }
-                      if (value != "" && int.parse(value) >= 1000000) { // 1 million +
+                      if (value.length >= 7) { // 1 million +
                         return "Quantity can't be so high";
+                      }
+                      if (value != "" && int.parse(value) == 0) {
+                        return "Quantity cannot be 0";
                       }
                       return null;
                     },

--- a/lib/pages/edit_item.dart
+++ b/lib/pages/edit_item.dart
@@ -192,7 +192,7 @@ class _EditItemWidgetState extends State<EditItemWidget> {
                 ),
                 const Padding(
                   padding: EdgeInsets.fromLTRB(16, 8, 0, 0),
-                  child: Text("Price (for one):"),
+                  child: Text("Price (for one):"), // TODO: Is this the best label I have?
                 ),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -297,7 +297,7 @@ class _EditItemWidgetState extends State<EditItemWidget> {
                       if (int.parse(value) == 0) {
                         return "Quantity cannot be 0";
                       }
-                      if (value != "" && int.parse(value) >= 1000000000) { // 1 billion +
+                      if (value != "" && int.parse(value) >= 1000000) { // 1 million +
                         return "Quantity can't be so high";
                       }
                       return null;
@@ -349,7 +349,7 @@ class _EditItemWidgetState extends State<EditItemWidget> {
                     controlAffinity: ListTileControlAffinity.leading, // leading checkbox
                   ),
                 ),
-              ]
+              ],
             ),
           ),
         ),

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -253,10 +253,10 @@ class _HomePageState extends State<HomePage> {
 
   void sortItemsByPrice(List<WishlistItem> items, {bool ascending = true}) {
     if (ascending) {
-      items.sort((item1, item2) => item1.price.compareTo(item2.price));
+      items.sort((item1, item2) => (item1.price * item1.quantity).compareTo(item2.price * item2.quantity));
     }
     else {
-      items.sort((item1, item2) => item2.price.compareTo(item1.price));
+      items.sort((item1, item2) => (item2.price * item2.quantity).compareTo(item1.price * item1.quantity));
     }
   }
 

--- a/lib/pages/view_item.dart
+++ b/lib/pages/view_item.dart
@@ -129,7 +129,7 @@ class _ViewItemWidgetState extends State<ViewItemWidget>{
                             const Divider(height: 0),
                             ItemPropertyRowWidget(icon: const Icon(Icons.category_outlined, semanticLabel: "Category"), text: Text(provider.categories[item.category]!)),
                             const Divider(height: 0),
-                            ItemPropertyRowWidget(
+                            ItemPropertyRowWidget( // TODO: Investigate showing total price vs price per unit
                               icon: const Icon(Icons.euro, semanticLabel: "Price"),
                               text: Consumer<SettingsProvider>(
                                 builder: (context, settingsProvider, child) => Text('${intl.NumberFormat.decimalPatternDigits(decimalDigits: 2).format(item.price)}${settingsProvider.currency}'),

--- a/lib/pages/view_item.dart
+++ b/lib/pages/view_item.dart
@@ -130,9 +130,12 @@ class _ViewItemWidgetState extends State<ViewItemWidget>{
                             ItemPropertyRowWidget(icon: const Icon(Icons.category_outlined, semanticLabel: "Category"), text: Text(provider.categories[item.category]!)),
                             const Divider(height: 0),
                             ItemPropertyRowWidget(
-                              icon: const Icon(Icons.euro, semanticLabel: "Price (for one)"),
+                              icon: const Icon(Icons.euro, semanticLabel: "Price"), // TODO: Show the price for one? Show the math?
                               text: Consumer<SettingsProvider>(
-                                builder: (context, settingsProvider, child) => Text('${intl.NumberFormat.decimalPatternDigits(decimalDigits: 2).format(item.price)}${settingsProvider.currency}'),
+                                builder: (context, settingsProvider, child) =>
+                                  Text("${intl.NumberFormat.decimalPatternDigits(decimalDigits: 2).format(item.price)}${settingsProvider.currency} "
+                                  "× ${item.quantity} = ${intl.NumberFormat.decimalPatternDigits(decimalDigits: 2).format(item.price * item.quantity)}"
+                                  "${settingsProvider.currency}"),
                               ),
                             ),
                             const Divider(height: 0),

--- a/lib/pages/view_item.dart
+++ b/lib/pages/view_item.dart
@@ -129,8 +129,8 @@ class _ViewItemWidgetState extends State<ViewItemWidget>{
                             const Divider(height: 0),
                             ItemPropertyRowWidget(icon: const Icon(Icons.category_outlined, semanticLabel: "Category"), text: Text(provider.categories[item.category]!)),
                             const Divider(height: 0),
-                            ItemPropertyRowWidget( // TODO: Investigate showing total price vs price per unit
-                              icon: const Icon(Icons.euro, semanticLabel: "Price"),
+                            ItemPropertyRowWidget(
+                              icon: const Icon(Icons.euro, semanticLabel: "Price (for one)"),
                               text: Consumer<SettingsProvider>(
                                 builder: (context, settingsProvider, child) => Text('${intl.NumberFormat.decimalPatternDigits(decimalDigits: 2).format(item.price)}${settingsProvider.currency}'),
                               ),

--- a/lib/pages/view_item.dart
+++ b/lib/pages/view_item.dart
@@ -130,7 +130,7 @@ class _ViewItemWidgetState extends State<ViewItemWidget>{
                             ItemPropertyRowWidget(icon: const Icon(Icons.category_outlined, semanticLabel: "Category"), text: Text(provider.categories[item.category]!)),
                             const Divider(height: 0),
                             ItemPropertyRowWidget(
-                              icon: const Icon(Icons.euro, semanticLabel: "Price"), // TODO: Show the price for one? Show the math?
+                              icon: const Icon(Icons.euro, semanticLabel: "Price"),
                               text: Consumer<SettingsProvider>(
                                 builder: (context, settingsProvider, child) =>
                                   Text("${intl.NumberFormat.decimalPatternDigits(decimalDigits: 2).format(item.price)}${settingsProvider.currency} "

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,0 +1,11 @@
+import 'package:intl/intl.dart' as intl;
+
+// Helper class for useful static functions
+class Utils {
+
+  /// Formats a [price] to be fairly short. If it is less than 5 (integer) digits long, it is shown with 2 decimal digits.
+  /// If it is larger, it is shown in a compact way, such as 10.2K, with a space added to the end to leave more space for the currency
+  static String formatPrice(double price) {
+    return price < 10000 ? intl.NumberFormat.decimalPatternDigits(decimalDigits: 2).format(price) : '${intl.NumberFormat.compact().format(price)} ';
+  }
+}

--- a/lib/widgets/item_card.dart
+++ b/lib/widgets/item_card.dart
@@ -35,10 +35,10 @@ class ItemCardWidget extends StatelessWidget {
             ),
             title: Text(item.name, maxLines: 1, overflow: TextOverflow.ellipsis),
             subtitle: Text(categoryName, maxLines: 1, overflow: TextOverflow.ellipsis),
-            trailing: // TODO: Investigate using total price vs price per unit
-              item.price < 10000 ?
-              Text('${intl.NumberFormat.decimalPatternDigits(decimalDigits: 2).format(item.price)}${provider.currency}') :
-              Text('${intl.NumberFormat.compact().format(item.price)} ${provider.currency}'),
+            trailing:
+              item.quantity * item.price < 10000 ?
+              Text('${intl.NumberFormat.decimalPatternDigits(decimalDigits: 2).format(item.quantity * item.price)}${provider.currency}') :
+              Text('${intl.NumberFormat.compact().format(item.quantity * item.price)} ${provider.currency}'),
           ),
         ),
       ),

--- a/lib/widgets/item_card.dart
+++ b/lib/widgets/item_card.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:wili/classes/item.dart';
 import 'package:wili/pages/view_item.dart';
 import 'package:wili/providers/settings_provider.dart';
-import 'package:intl/intl.dart' as intl;
+import 'package:wili/utils/utils.dart';
 
 class ItemCardWidget extends StatelessWidget {
   const ItemCardWidget({super.key, required this.item, required this.categoryName});
@@ -35,10 +35,7 @@ class ItemCardWidget extends StatelessWidget {
             ),
             title: Text(item.name, maxLines: 1, overflow: TextOverflow.ellipsis),
             subtitle: Text(categoryName, maxLines: 1, overflow: TextOverflow.ellipsis),
-            trailing:
-              item.quantity * item.price < 10000 ?
-              Text('${intl.NumberFormat.decimalPatternDigits(decimalDigits: 2).format(item.quantity * item.price)}${provider.currency}') :
-              Text('${intl.NumberFormat.compact().format(item.quantity * item.price)} ${provider.currency}'),
+            trailing: Text('${Utils.formatPrice(item.quantity * item.price)}${provider.currency}'),
           ),
         ),
       ),

--- a/lib/widgets/item_card.dart
+++ b/lib/widgets/item_card.dart
@@ -35,7 +35,7 @@ class ItemCardWidget extends StatelessWidget {
             ),
             title: Text(item.name, maxLines: 1, overflow: TextOverflow.ellipsis),
             subtitle: Text(categoryName, maxLines: 1, overflow: TextOverflow.ellipsis),
-            trailing:
+            trailing: // TODO: Investigate using total price vs price per unit
               item.price < 10000 ?
               Text('${intl.NumberFormat.decimalPatternDigits(decimalDigits: 2).format(item.price)}${provider.currency}') :
               Text('${intl.NumberFormat.compact().format(item.price)} ${provider.currency}'),

--- a/lib/widgets/list_widget.dart
+++ b/lib/widgets/list_widget.dart
@@ -32,29 +32,61 @@ class ListWidget extends StatelessWidget {
       );
     }
     else { // TODO: Add total prices (Perhaps total not purchased + total purchased) (take quantity into account)
-      return ListView.builder(
-        itemCount: items.length,
-        itemBuilder: (context, index) {
-          if (Provider.of<SettingsProvider>(context).moveToBot && index != items.length - 1 && !items[index].purchased && items[index + 1].purchased) {
-            return Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
+      double totalPrice = 0;
+      double notPurchasedPrice = 0;
+      for (WishlistItem item in items) {
+        double itemPrice = item.quantity * item.price;
+        if (!item.purchased) {
+          notPurchasedPrice += itemPrice;
+        }
+        totalPrice += itemPrice;
+      }
+
+      return Column(
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                  child: Text("Price (not purchased): $notPurchasedPrice", textAlign: TextAlign.left,),
+                ),
+              ),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                  child: Text("Total price: $totalPrice", textAlign: TextAlign.right,),
+                ),
+              ),
+            ],
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: items.length,
+              itemBuilder: (context, index) {
+                if (Provider.of<SettingsProvider>(context).moveToBot && index != items.length - 1 && !items[index].purchased && items[index + 1].purchased) {
+                  return Column(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
+                        child: ItemCardWidget(item: items[index], categoryName: categories[items[index].category]!),
+                      ),
+                      const Padding(
+                        padding: EdgeInsets.symmetric(vertical: 4.0, horizontal: 12.0),
+                        child: Divider(height: 0),
+                      ),
+                    ],
+                  );
+                }
+                return Padding(
+                  // The last item gets considerably more padding on the bottom, in order for the floating action button to not hide any item's price
+                  padding: index == items.length - 1 ? const EdgeInsets.fromLTRB(8.0, 4.0, 8.0, 55.0): const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
                   child: ItemCardWidget(item: items[index], categoryName: categories[items[index].category]!),
-                ),
-                const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 4.0, horizontal: 12.0),
-                  child: Divider(height: 0),
-                ),
-              ],
-            );
-          }
-          return Padding(
-            // The last item gets considerably more padding on the bottom, in order for the floating action button to not hide any item's price
-            padding: index == items.length - 1 ? const EdgeInsets.fromLTRB(8.0, 4.0, 8.0, 55.0): const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
-            child: ItemCardWidget(item: items[index], categoryName: categories[items[index].category]!),
-          );
-        },
+                );
+              },
+            ),
+          ),
+        ],
       );
     }
   }

--- a/lib/widgets/list_widget.dart
+++ b/lib/widgets/list_widget.dart
@@ -3,6 +3,8 @@ import 'package:provider/provider.dart';
 import 'package:wili/classes/item.dart';
 import 'package:wili/providers/settings_provider.dart';
 import 'package:wili/widgets/item_card.dart';
+import 'package:intl/intl.dart' as intl;
+
 
 class ListWidget extends StatelessWidget {
   const ListWidget({
@@ -13,6 +15,11 @@ class ListWidget extends StatelessWidget {
 
   final List<WishlistItem> items;
   final Map<int, String> categories;
+
+  // TODO: Move this outside of this class and use it in other places as well
+  String formatPrice(double price) {
+    return price < 10000 ? intl.NumberFormat.decimalPatternDigits(decimalDigits: 2).format(price) : '${intl.NumberFormat.compact().format(price)} ';
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -44,19 +51,21 @@ class ListWidget extends StatelessWidget {
 
       return Column(
         children: [
-          Row(
-            children: [
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                  child: Text("Price (not purchased): $notPurchasedPrice${Provider.of<SettingsProvider>(context).currency}", textAlign: TextAlign.left,),
+          Consumer<SettingsProvider>(
+            builder: (context, provider, row) => Row(
+              children: [
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                    child: Text("Not purchased: ${formatPrice(notPurchasedPrice)}${provider.currency}", textAlign: TextAlign.left,),
+                  ),
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                child: Text("Total price: $totalPrice${Provider.of<SettingsProvider>(context).currency}", textAlign: TextAlign.right,),
-              ),
-            ],
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                  child: Text("Total price: ${formatPrice(totalPrice)}${provider.currency}", textAlign: TextAlign.right,),
+                ),
+              ],
+            ),
           ),
           Expanded(
             child: ListView.builder(

--- a/lib/widgets/list_widget.dart
+++ b/lib/widgets/list_widget.dart
@@ -52,11 +52,9 @@ class ListWidget extends StatelessWidget {
                   child: Text("Price (not purchased): $notPurchasedPrice${Provider.of<SettingsProvider>(context).currency}", textAlign: TextAlign.left,),
                 ),
               ),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                  child: Text("Total price: $totalPrice${Provider.of<SettingsProvider>(context).currency}", textAlign: TextAlign.right,),
-                ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                child: Text("Total price: $totalPrice${Provider.of<SettingsProvider>(context).currency}", textAlign: TextAlign.right,),
               ),
             ],
           ),

--- a/lib/widgets/list_widget.dart
+++ b/lib/widgets/list_widget.dart
@@ -32,7 +32,7 @@ class ListWidget extends StatelessWidget {
         ],
       );
     }
-    else { // TODO: Add total prices (Perhaps total not purchased + total purchased) (take quantity into account)
+    else {
       double totalPrice = 0;
       double notPurchasedPrice = 0;
       for (WishlistItem item in items) {
@@ -45,20 +45,43 @@ class ListWidget extends StatelessWidget {
 
       return Column(
         children: [
-          Consumer<SettingsProvider>(
-            builder: (context, provider, row) => Row(
-              children: [
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                    child: Text("Not purchased: ${Utils.formatPrice(notPurchasedPrice)}${provider.currency}", textAlign: TextAlign.left,),
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 3.0),
+            child: Consumer<SettingsProvider>(
+              builder: (context, provider, row) => Row(
+                children: [
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+                      child: RichText(
+                        textAlign: TextAlign.left,
+                        text: TextSpan(
+                          style: DefaultTextStyle.of(context).style,
+                          children: [
+                            const TextSpan(text: "Not purchased: "), // TODO: Show it like this?
+                            TextSpan(text: "${Utils.formatPrice(notPurchasedPrice)}${provider.currency}", style: const TextStyle(fontWeight: FontWeight.bold)),
+                          ],
+                        ),
+                      ),
+                      // child: Text("Not purchased: ${Utils.formatPrice(notPurchasedPrice)}${provider.currency}", textAlign: TextAlign.left,),
+                    ),
                   ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                  child: Text("Total price: ${Utils.formatPrice(totalPrice)}${provider.currency}", textAlign: TextAlign.right,),
-                ),
-              ],
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 12.0),
+                    child: RichText(
+                      textAlign: TextAlign.right,
+                      text: TextSpan(
+                        style: DefaultTextStyle.of(context).style,
+                        children: [
+                          const TextSpan(text: "Total price: "),
+                          TextSpan(text: "${Utils.formatPrice(totalPrice)}${provider.currency}", style: const TextStyle(fontWeight: FontWeight.bold)),
+                        ],
+                      ),
+                    ),
+                    // child: Text("Total price: ${Utils.formatPrice(totalPrice)}${provider.currency}", textAlign: TextAlign.right,),
+                  ),
+                ],
+              ),
             ),
           ),
           Expanded(

--- a/lib/widgets/list_widget.dart
+++ b/lib/widgets/list_widget.dart
@@ -58,8 +58,11 @@ class ListWidget extends StatelessWidget {
                         text: TextSpan(
                           style: DefaultTextStyle.of(context).style,
                           children: [
-                            const TextSpan(text: "Not purchased: "), // TODO: Show it like this?
-                            TextSpan(text: "${Utils.formatPrice(notPurchasedPrice)}${provider.currency}", style: const TextStyle(fontWeight: FontWeight.bold)),
+                            const TextSpan(text: "Not purchased: "),
+                            TextSpan(
+                              text: "${Utils.formatPrice(notPurchasedPrice)}${provider.currency}",
+                              style: const TextStyle(fontWeight: FontWeight.bold),
+                            ),
                           ],
                         ),
                       ),
@@ -74,7 +77,10 @@ class ListWidget extends StatelessWidget {
                         style: DefaultTextStyle.of(context).style,
                         children: [
                           const TextSpan(text: "Total price: "),
-                          TextSpan(text: "${Utils.formatPrice(totalPrice)}${provider.currency}", style: const TextStyle(fontWeight: FontWeight.bold)),
+                          TextSpan(
+                            text: "${Utils.formatPrice(totalPrice)}${provider.currency}",
+                            style: const TextStyle(fontWeight: FontWeight.bold),
+                          ),
                         ],
                       ),
                     ),

--- a/lib/widgets/list_widget.dart
+++ b/lib/widgets/list_widget.dart
@@ -49,13 +49,13 @@ class ListWidget extends StatelessWidget {
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                  child: Text("Price (not purchased): $notPurchasedPrice", textAlign: TextAlign.left,),
+                  child: Text("Price (not purchased): $notPurchasedPrice${Provider.of<SettingsProvider>(context).currency}", textAlign: TextAlign.left,),
                 ),
               ),
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                  child: Text("Total price: $totalPrice", textAlign: TextAlign.right,),
+                  child: Text("Total price: $totalPrice${Provider.of<SettingsProvider>(context).currency}", textAlign: TextAlign.right,),
                 ),
               ),
             ],

--- a/lib/widgets/list_widget.dart
+++ b/lib/widgets/list_widget.dart
@@ -31,7 +31,7 @@ class ListWidget extends StatelessWidget {
         ],
       );
     }
-    else {
+    else { // TODO: Add total prices (Perhaps total not purchased + total purchased) (take quantity into account)
       return ListView.builder(
         itemCount: items.length,
         itemBuilder: (context, index) {

--- a/lib/widgets/list_widget.dart
+++ b/lib/widgets/list_widget.dart
@@ -3,8 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:wili/classes/item.dart';
 import 'package:wili/providers/settings_provider.dart';
 import 'package:wili/widgets/item_card.dart';
-import 'package:intl/intl.dart' as intl;
-
+import 'package:wili/utils/utils.dart';
 
 class ListWidget extends StatelessWidget {
   const ListWidget({
@@ -15,11 +14,6 @@ class ListWidget extends StatelessWidget {
 
   final List<WishlistItem> items;
   final Map<int, String> categories;
-
-  // TODO: Move this outside of this class and use it in other places as well
-  String formatPrice(double price) {
-    return price < 10000 ? intl.NumberFormat.decimalPatternDigits(decimalDigits: 2).format(price) : '${intl.NumberFormat.compact().format(price)} ';
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -57,12 +51,12 @@ class ListWidget extends StatelessWidget {
                 Expanded(
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                    child: Text("Not purchased: ${formatPrice(notPurchasedPrice)}${provider.currency}", textAlign: TextAlign.left,),
+                    child: Text("Not purchased: ${Utils.formatPrice(notPurchasedPrice)}${provider.currency}", textAlign: TextAlign.left,),
                   ),
                 ),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                  child: Text("Total price: ${formatPrice(totalPrice)}${provider.currency}", textAlign: TextAlign.right,),
+                  child: Text("Total price: ${Utils.formatPrice(totalPrice)}${provider.currency}", textAlign: TextAlign.right,),
                 ),
               ],
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -332,26 +332,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -380,10 +380,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -625,10 +625,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -713,10 +713,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+2
+version: 1.0.2+3
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
Closes #2 and #3.

Design choices: 

- Total price is shown in the home page, and used for sorting. Full calculation is shown in ViewItem page (eg 25.00$ × 3 = 75.00$)
- Show two price counters, below the filters, when at least one item exists:
1. price for un-purchased
2. total price